### PR TITLE
added support for multiple selections for toUpper, toLower and toTitle

### DIFF
--- a/lib/stringConvert.js
+++ b/lib/stringConvert.js
@@ -85,6 +85,21 @@ define(function (require, exports, module) {
         }
         
     }
+    
+    /**
+     * @function _getMultiple -- returns array of strings selected with multiple cursors
+     */
+    
+    function _getMultiple(){
+        var editor = EditorManager.getCurrentFullEditor();
+        if (!editor) return [];
+        
+        var doc = DocumentManager.getCurrentDocument();
+        
+        return editor.getSelections().map(function(selection){
+            return doc.getRange(selection.start, selection.end);
+        });
+    }
 
     /**
      * Editor set select area or all text.
@@ -117,6 +132,24 @@ define(function (require, exports, module) {
             });
         }        
     }
+    
+    /**
+     * @function _setMultiple - fills mulltiple selected ranges with provided text
+     * @param {array<String>} - array with text selection to be replaced with; the length
+     *                          of this array must be equal the length of selections array
+     */
+    
+    function _setMultiple(result){
+        var editor = EditorManager.getCurrentFullEditor();
+        if (!editor) return;
+        
+        var selections = editor.getSelections();
+        var doc = DocumentManager.getCurrentDocument();
+        
+        selections.forEach(function(selection, index){
+            doc.replaceRange(result[index], selection.start, selection.end);
+        });
+    }
      
     function removeBreaklines(){
         
@@ -134,28 +167,31 @@ define(function (require, exports, module) {
  
     function toUppper() {
         
-        var result = _get().toUpperCase(); 
-        _set(result);
+        var result = _getMultiple().map(function(str){
+            return str.toUpperCase();
+        }); 
+        _setMultiple(result);
     }
 
     function toLower() {
         
-       var result = _get().toLowerCase(); 
-        _set(result);
+        var result = _getMultiple().map(function(str){
+            return str.toLowerCase();
+        }); 
+        _setMultiple(result);
     }
     
     function toTitle() {
-
-       var result = _get(); 
-
-        result = result.toLowerCase().replace(/_/g, ' ');
-        result = result.replace(/\b([a-z\u00C0-\u00ff])/g, function (_, initial) {
-            return initial.toUpperCase();
-        }).replace(/(\s(?:de|a|o|e|da|do|em|ou|[\u00C0-\u00ff]))\b/ig, function (_, match) {
-            return match.toLowerCase();
-        });
+        var result = _getMultiple().map(function(str){
+            str = str.toLowerCase().replace(/_/g, ' ');
+            return str.replace(/\b([a-z\u00C0-\u00ff])/g, function (_, initial) {
+                return initial.toUpperCase();
+            }).replace(/(\s(?:de|a|o|e|da|do|em|ou|[\u00C0-\u00ff]))\b/ig, function (_, match) {
+                return match.toLowerCase();
+            });
+        }); 
         
-        _set(result);
+        _setMultiple(result);
     }
 
     function urlEncode() {


### PR DESCRIPTION
Hello!
I think that it should be more useful to be able to change case for multiple selections then for entire document (and you always can use `ctrl+A` for this purpose). So I implement multiple selections support for toUpper, toLower and toTitle methods. 